### PR TITLE
Issue #27 refactor: Add GDSC_Logo file to recycle anywhere

### DIFF
--- a/src/components/common/gdscLogo/GDSC_Logo.jsx
+++ b/src/components/common/gdscLogo/GDSC_Logo.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+import { flexNone } from '../../../layout/flexbox';
+
+const LogoContainer = styled.div`
+    ${flexNone};
+    display: inline-block;
+`;
+
+const GDSCText = styled.h3`
+    &:first-child {
+        font-size: 14px;
+        padding-bottom: 2px;
+    };
+    &:nth-child(2) {
+        font-size: 10px;
+    };
+    font-family: 'googleSansDisplayRegular';
+`;
+
+const Div = styled.div`
+    display: inline-block;
+    vertical-align: middle;
+    &:nth-child(2) {
+        padding-left: 10px;
+    }
+`;
+
+const Logo = styled.img`
+    width: 50px;
+    height: 50px;
+`;
+
+function GDSCLogo() {
+    return (
+        <LogoContainer>
+            <Div>
+                <Logo src='/assets/logo/GDSC_Logo.svg' alt="GDSCpknu 로고" />
+            </Div>
+            <Div>
+                <GDSCText>
+                    Google Developer Student Clubs
+                </GDSCText>
+                <GDSCText>
+                    Pukyong University
+                </GDSCText>
+            </Div>
+        </LogoContainer>
+    )
+}
+
+export default GDSCLogo;


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
<!-- 요약
- Resolve: #{이슈넘버} // 해결한 이슈
- Related: #{이슈넘버} // 연관된 이슈
- 참고: [요약](링크)    // 참고한 링크
--> Resolve: #27 

## Changes
<!-- 변경사항 -->
반복해서 사용되는 gdsc로고를 재사용할 수 있게 파일을 만듦