### PR TITLE
Issue #45 docs Modify layout padding margins

### DIFF
--- a/src/components/faqpage/FaqPage.jsx
+++ b/src/components/faqpage/FaqPage.jsx
@@ -13,7 +13,7 @@ const FaqContainer = styled.div`
 
 const FaqWrapper = styled.div`
     width:100%;
-    max-width:1300px;
+    max-width:1270px;
     padding:150px;
     margin: 0 auto;
 `;
@@ -21,8 +21,9 @@ const FaqWrapper = styled.div`
 const FaqTitle = styled.div`
     font-size: ${fontSizes['6xl']};
     margin-bottom: ${space[20]};
-    padding: ${space[4]} ${space[8]};
+    padding: ${space[4]} ${space[2]} ${space[4]} ${space[16]};
     border-left : ${space[4]} solid ${color.gdscBlue};
+    white-space : nowrap;
 `;
 
 const FaqText = styled.span`


### PR DESCRIPTION
<!-- 선행
- Assignees 지정
- Labels 지정 (옵션)
- Milestone 지정 (옵션)
-->

## What is the PR?
<!-- 요약
- Resolve: #{이슈넘버} // 해결한 이슈
- Related: #{이슈넘버} // 연관된 이슈
- 참고: [요약](링크)    // 참고한 링크
-->
- Related: #46 
## Changes
<!-- 변경사항 -->
- 페이지 전체의 최대 너비를 헤더에 맞춰서 수정(줄임)
- 제목 부분에 여백을 수정하여 헤더와 아래 텍스트의 간격에 맞추어 수정

## Screenshots
<!-- 스크린샷 (Optional)
- 양식: <img src="" width=350 />
-->
![image](https://user-images.githubusercontent.com/102893626/190410870-0a24b9cc-8261-470f-a927-5f0d42be8f6d.png)

## etc
<!-- 비고
- 트러블슈팅 공유, 고민 등을 서술
-->
- 실제 내용이 들어간 텍스트 부분은 현재 높이를 조정할 시 아래에 생성된 라인도 함께 위치가 수정되기 때문에 현재는 고정된 높이로 수정하지 않아 이후에 반응형이 들어간다면 함께 수정해야함